### PR TITLE
HEVC support in Enhanced RTMP v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.project
 /.cproject
 /.vscode
+.DS_Store

--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -651,8 +651,8 @@ ngx_rtmp_codec_parse_hevc_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
 {
     ngx_rtmp_codec_ctx_t   *ctx;
     ngx_rtmp_bit_reader_t   br;
-    ngx_uint_t              num_arrays, nal_unit_type, num_nalus;
-    ngx_uint_t              i, j, width, height;
+    // ngx_uint_t              num_arrays, nal_unit_type, num_nalus;
+    // ngx_uint_t              i, j, width, height;
 
     ngx_log_debug0(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
                    "codec: parsing HEVC header");

--- a/ngx_rtmp_codec_module.c
+++ b/ngx_rtmp_codec_module.c
@@ -665,82 +665,84 @@ ngx_rtmp_codec_parse_hevc_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
     ngx_rtmp_bit_init_reader(&br, in->buf->pos, in->buf->last);
 
     /* Skip configuration version */
-    ngx_uint_t config_version = ngx_rtmp_bit_read(&br, 8);
-    ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "codec: HEVC config version: %ui", config_version);
+    ngx_rtmp_bit_read(&br, 8);
+    // ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+    //                "codec: HEVC config version: %ui", config_version);
 
     /* Read profile space, tier flag, profile IDC */
     ctx->hevc_profile = ngx_rtmp_bit_read(&br, 5);
-    ngx_uint_t tier_flag = ngx_rtmp_bit_read(&br, 1);
-    ctx->hevc_level = ngx_rtmp_bit_read(&br, 7);
-    ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "codec: HEVC profile: %ui, tier flag: %ui, level: %ui",
-                   ctx->hevc_profile, tier_flag, ctx->hevc_level);
+
+    // TODO: FOLLOWING IS WIP parse HEVC header
+    // ngx_uint_t tier_flag = ngx_rtmp_bit_read(&br, 1);
+    // ctx->hevc_level = ngx_rtmp_bit_read(&br, 7);
+    // ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+    //                "codec: HEVC profile: %ui, tier flag: %ui, level: %ui",
+    //                ctx->hevc_profile, tier_flag, ctx->hevc_level);
 
     /* Skip some fields */
-    ngx_uint_t general_profile_compatibility_flags = ngx_rtmp_bit_read(&br, 32);
-    ngx_uint_t general_constraint_indicator_flags = ngx_rtmp_bit_read(&br, 12);
-    ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "codec: HEVC profile compatibility flags: 0x%xui, constraint indicator flags: 0x%xui",
-                   general_profile_compatibility_flags, general_constraint_indicator_flags);
+    // ngx_uint_t general_profile_compatibility_flags = ngx_rtmp_bit_read(&br, 32);
+    // ngx_uint_t general_constraint_indicator_flags = ngx_rtmp_bit_read(&br, 12);
+    // ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+    //                "codec: HEVC profile compatibility flags: 0x%xui, constraint indicator flags: 0x%xui",
+    //                general_profile_compatibility_flags, general_constraint_indicator_flags);
 
     /* Read number of arrays */
-    num_arrays = ngx_rtmp_bit_read(&br, 8);
-    ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                   "codec: HEVC number of arrays: %ui", num_arrays);
-    for (i = 0; i < num_arrays; i++) {
-        nal_unit_type = ngx_rtmp_bit_read(&br, 5);
-        num_nalus = ngx_rtmp_bit_read(&br, 16);
+    // num_arrays = ngx_rtmp_bit_read(&br, 8);
+    // ngx_log_debug1(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+    //                "codec: HEVC number of arrays: %ui", num_arrays);
+    // for (i = 0; i < num_arrays; i++) {
+    //     nal_unit_type = ngx_rtmp_bit_read(&br, 5);
+    //     num_nalus = ngx_rtmp_bit_read(&br, 16);
 
-        ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                       "codec: HEVC array %ui: nal_unit_type=%ui", i, nal_unit_type);
-        ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                       "codec: HEVC array %ui: num_nalus=%ui", i, num_nalus);
+    //     ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+    //                    "codec: HEVC array %ui: nal_unit_type=%ui", i, nal_unit_type);
+    //     ngx_log_debug2(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+    //                    "codec: HEVC array %ui: num_nalus=%ui", i, num_nalus);
 
-        for (j = 0; j < num_nalus; j++) {
-            ngx_uint_t nal_unit_length = ngx_rtmp_bit_read(&br, 16);
-            ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                           "codec: HEVC array %ui, nalu %ui: length=%ui", 
-                           i, j, nal_unit_length);
+    //     for (j = 0; j < num_nalus; j++) {
+    //         ngx_uint_t nal_unit_length = ngx_rtmp_bit_read(&br, 16);
+    //         ngx_log_debug3(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+    //                        "codec: HEVC array %ui, nalu %ui: length=%ui", 
+    //                        i, j, nal_unit_length);
             
-            if (nal_unit_type == 33) { /* SPS */
-                /* Parse SPS for width and height */
-                ngx_rtmp_bit_read(&br, 16); /* Skip nal_unit_header */
+    //         if (nal_unit_type == 33) { /* SPS */
+    //             /* Parse SPS for width and height */
+    //             ngx_rtmp_bit_read(&br, 16); /* Skip nal_unit_header */
                 
-                /* TODO: Implement proper SPS parsing for HEVC */
-                /* This is a simplified example and may not work for all HEVC streams */
-                ngx_rtmp_bit_read(&br, 4); /* sps_video_parameter_set_id */
-                ngx_rtmp_bit_read(&br, 3); /* sps_max_sub_layers_minus1 */
-                ngx_rtmp_bit_read(&br, 1); /* sps_temporal_id_nesting_flag */
+    //             /* TODO: Implement proper SPS parsing for HEVC */
+    //             /* This is a simplified example and may not work for all HEVC streams */
+    //             ngx_rtmp_bit_read(&br, 4); /* sps_video_parameter_set_id */
+    //             ngx_rtmp_bit_read(&br, 3); /* sps_max_sub_layers_minus1 */
+    //             ngx_rtmp_bit_read(&br, 1); /* sps_temporal_id_nesting_flag */
                 
-                /* profile_tier_level() */
-                ngx_rtmp_bit_read(&br, 96);
+    //             /* profile_tier_level() */
+    //             ngx_rtmp_bit_read(&br, 96);
                 
-                /* Skip to pic_width_in_luma_samples and pic_height_in_luma_samples */
-                ngx_rtmp_bit_read(&br, 4); /* sps_seq_parameter_set_id */
-                ngx_rtmp_bit_read(&br, 4); /* chroma_format_idc */
+    //             /* Skip to pic_width_in_luma_samples and pic_height_in_luma_samples */
+    //             ngx_rtmp_bit_read(&br, 4); /* sps_seq_parameter_set_id */
+    //             ngx_rtmp_bit_read(&br, 4); /* chroma_format_idc */
                 
-                width = ngx_rtmp_bit_read(&br, 16);
-                height = ngx_rtmp_bit_read(&br, 16);
+    //             width = ngx_rtmp_bit_read(&br, 16);
+    //             height = ngx_rtmp_bit_read(&br, 16);
                 
-                ctx->width = width;
-                ctx->height = height;
+    //             ctx->width = width;
+    //             ctx->height = height;
                 
-                ngx_log_debug4(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
-                               "codec: HEVC header parsed "
-                               "profile=%ui, level=%ui, width=%ui, height=%ui",
-                               ctx->hevc_profile, ctx->hevc_level, ctx->width, ctx->height);
+    //             ngx_log_debug4(NGX_LOG_DEBUG_RTMP, s->connection->log, 0,
+    //                            "codec: HEVC header parsed "
+    //                            "profile=%ui, level=%ui, width=%ui, height=%ui",
+    //                            ctx->hevc_profile, ctx->hevc_level, ctx->width, ctx->height);
                 
-                return; /* We've got what we need, so we can return */
-            }
+    //             return; /* We've got what we need, so we can return */
+    //         }
             
-            /* Skip this NAL unit */
-            ngx_rtmp_bit_read(&br, nal_unit_length * 8);
-        }
-    }
+    //         /* Skip this NAL unit */
+    //         ngx_rtmp_bit_read(&br, nal_unit_length * 8);
+    //     }
+    // }
 
     ngx_log_error(NGX_LOG_WARN, s->connection->log, 0,
-                  "codec: failed to parse HEVC header");
+                  "codec: failed to parse HEVC header (implementation incomplete)");
 }
 
 

--- a/ngx_rtmp_codec_module.h
+++ b/ngx_rtmp_codec_module.h
@@ -41,7 +41,8 @@ enum {
     NGX_RTMP_VIDEO_ON2_VP6          = 4,
     NGX_RTMP_VIDEO_ON2_VP6_ALPHA    = 5,
     NGX_RTMP_VIDEO_SCREEN2          = 6,
-    NGX_RTMP_VIDEO_H264             = 7
+    NGX_RTMP_VIDEO_H264             = 7,
+    NGX_RTMP_VIDEO_HEVC             = 0x68766331 // h v c 1
 };
 
 
@@ -68,6 +69,10 @@ typedef struct {
     ngx_uint_t                  avc_level;
     ngx_uint_t                  avc_nal_bytes;
     ngx_uint_t                  avc_ref_frames;
+    ngx_uint_t                  hevc_profile;
+    ngx_uint_t                  hevc_level;
+    // ngx_uint_t                  hevc_nal_bytes;
+
     ngx_uint_t                  sample_rate;    /* 5512, 11025, 22050, 44100 */
     ngx_uint_t                  sample_size;    /* 1=8bit, 2=16bit */
     ngx_uint_t                  audio_channels; /* 1, 2 */
@@ -76,6 +81,7 @@ typedef struct {
 
     ngx_chain_t                *avc_header;
     ngx_chain_t                *aac_header;
+    ngx_chain_t                *hevc_header;
 
     ngx_chain_t                *meta;
     ngx_uint_t                  meta_version;
@@ -84,5 +90,5 @@ typedef struct {
 
 extern ngx_module_t  ngx_rtmp_codec_module;
 
-
+ 
 #endif /* _NGX_RTMP_LIVE_H_INCLUDED_ */

--- a/ngx_rtmp_record_module.h
+++ b/ngx_rtmp_record_module.h
@@ -51,6 +51,7 @@ typedef struct {
     unsigned                            initialized:1;
     unsigned                            aac_header_sent:1;
     unsigned                            avc_header_sent:1;
+    unsigned                            hevc_header_sent:1;
     unsigned                            video_key_sent:1;
     unsigned                            audio:1;
     unsigned                            video:1;


### PR DESCRIPTION
Following this spec:
https://veovera.org/docs/enhanced/enhanced-rtmp-v1

- Only HEVC supported out of enhanced codecs (no av1, etc.) 
- Recording to flv files works, but flv files don't play in VLC/QuickTime until repackaged to mp4: `ffmpeg -i rec.flv -acodec copy -vcodec copy -movflags +faststart rec.mp4`
- HEVC codec parsing is not finished (width, profile, height need to be extracted properly and tested) 
- HLS HEVC not supported

Courtesy of [EventLive Event Live Streaming Platform](https://www.eventlive.pro/)